### PR TITLE
TagStand Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
            <a id="thanks-to-our-sponsor" aria-hidden="true"><span class="octicon octicon-link"></span></a>Thanks To Our Sponsors
          </h3spon>
 
-          <p><img src="http://www.tagstand.com/files/cache/3be8f98c031f3e03775307cfda19e55e_f175.png" alt="Tagstand"></p>
+          <a href = "http://www.tagstand.com"><p><img src="http://www.tagstand.com/files/cache/3be8f98c031f3e03775307cfda19e55e_f175.png" alt="Tagstand"></p></a>
 
      </sponsorblock>
     </sponsorbody>


### PR DESCRIPTION
In this commit, when you click on the picture of TagStand's logo on the
bottom of the page, the website will redirect you to TagStand's website
"http://www.tagstand.com"